### PR TITLE
remove propaganda

### DIFF
--- a/_data/netlist.yaml
+++ b/_data/netlist.yaml
@@ -949,30 +949,6 @@ PTlink:
   category:
     - regional
   status: down
-RusNet:
-  image: /media/flags/ru-flag.png
-  homepage: "http://www.rus-net.org/"
-  webchat:
-  slocation: Russia, Ukraine, Latvia, USA
-  services:
-  support_channels:
-  information: >
-    RusNet serves the Russian-speaking community with servers spread throughout the former Soviet Union and a few more outside it.
-  servers:
-    - irc.lucky.net
-    - irc.anarxi.st
-    - irc.mv.ru
-    - irc.seb.org.ua
-    - irc.odessa.ua
-    - irc.tsua.net
-    - irc.tomsk.net
-  webserverlist:
-  webstatistic:
-  category:
-    - regional
-  status: active
-  check:
-    server: irc.lucky.net
 ZAIRC:
   image: /media/flags/za-flag.png
   homepage: "https://zairc.net/"


### PR DESCRIPTION
Rusnet problem description
  slocation: Russia, Ukraine, Latvia, USA
  information: >
    RusNet serves the Russian-speaking community with servers spread throughout the former Soviet Union and a few more outside it.
=== Rationale for removal === Rusnet description was not regional but imperialistic- mentioning occupied countries as collaborators.
They were never soviet union countries, but occupied, like whole Russia is before Soviet union multiple occupied countries. This is propaganda that USA, Latvia and Ukraine are post soviet, maybe Russia is post soviet, to act that they have nothing to do with people they left in other occupied territories, so they wont have country to be deported of and wont have existing country passport. USA were not even close but others- They were occupied and were not post-soviet occupation, they were before occupation. Calling something that was made is a complete delusion of history propaganda from USSR Russia lies. Also theese irc servers are not checked with bot if are up at all, so i checked and they are all down. If some works- cant be used for propaganda purposes. === Additional- war ===
Because of Russia war trying to occupy Ukraine most Russian servers are blocked. Especially for propaganda purposes.