### PR TITLE
Update catlist.yaml

### DIFF
--- a/_data/catlist.yaml
+++ b/_data/catlist.yaml
@@ -86,7 +86,6 @@ regional:
 - PTlink
 - Red Latina
 - RedeBrasil
-- RusNet
 - SurNet
 - ThaiNet
 - UniBG


### PR DESCRIPTION
Rusnet description was not regional but imperialistic- mentioning occupied countries as collaborators.